### PR TITLE
Fix license comments in tests

### DIFF
--- a/hr_attendance_multi_rfid/tests/test_functional.py
+++ b/hr_attendance_multi_rfid/tests/test_functional.py
@@ -1,5 +1,5 @@
 # Copyright 2022 Polimex Holding Ltd..
-# License APL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from dateutil.relativedelta import relativedelta
 
 from odoo.addons.hr_rfid.tests.test_functional import RFIDTests

--- a/hr_rfid/tests/test_functional.py
+++ b/hr_rfid/tests/test_functional.py
@@ -1,5 +1,5 @@
 # Copyright 2022 Polimex Holding Ltd..
-# License APL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from dateutil.relativedelta import relativedelta
 
 from odoo.addons.hr_rfid.tests.controller import RFIDController

--- a/rfid_service_base/tests/test_services.py
+++ b/rfid_service_base/tests/test_services.py
@@ -1,5 +1,5 @@
 # Copyright 2022 Polimex Holding Ltd..
-# License APL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from datetime import timedelta, datetime, time
 
 from odoo import fields


### PR DESCRIPTION
## Summary
- update license header in `hr_rfid` tests
- update license header in `hr_attendance_multi_rfid` tests
- update license header in `rfid_service_base` tests

## Testing
- `pytest -q` *(fails: `pytest: command not found`)*