### PR TITLE
Fix cctv.camera create loop

### DIFF
--- a/polimex_ip_cam/models/cctv_camera.py
+++ b/polimex_ip_cam/models/cctv_camera.py
@@ -165,7 +165,7 @@ class CctvCamera(models.Model):
     def create(self, vals_list):
         new_records = self.env['cctv.camera']
         for vals in vals_list:
-            new_record = super().create(vals_list)
+            new_record = super().create(vals)
             reader_in_id = self.env['hr.rfid.reader'].sudo().create([{
                 'name': _('In Reader %s', new_record.name),
                 'reader_type': '0', # In reader


### PR DESCRIPTION
## Summary
- fix create loop argument so per-element record creation works

## Testing
- `pytest -q` *(fails: command not found)*